### PR TITLE
Include netty-common and netty-buffer in this plugin package

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,7 @@ sourceCompatibility = 1.8
 targetCompatibility = 1.8
 
 dependencies {
-    compile  "org.embulk:embulk-core:0.9.7"
+    compile  "org.embulk:embulk-core:0.9.20"
     compile("com.datastax.cassandra:cassandra-driver-core:3.5.0") {
         exclude module: 'netty-buffer'
         exclude module: 'netty-codec'
@@ -27,13 +27,21 @@ dependencies {
         exclude module: 'netty-handler'
         exclude module: 'netty-transport'
     }
+
+    // These two are included in embulk-core, but they are planned to be hidden from plugins.
+    // Including them in this plugin should not cause problems even against embulk-core with Netty.
+    //
+    // TODO: Use cassandra-driver-core's own Netty dependencies once embulk-core without Netty gets popular.
+    compile  "io.netty:netty-common:4.0.44.Final"
+    compile  "io.netty:netty-buffer:4.0.44.Final"
+
     compile  "io.netty:netty-codec:4.0.44.Final"
     compile  "io.netty:netty-handler:4.0.44.Final"
     compile  "io.netty:netty-transport:4.0.44.Final"
-    provided "org.embulk:embulk-core:0.9.7"
+    provided "org.embulk:embulk-core:0.9.20"
     testCompile "junit:junit:4.+"
-    testCompile  "org.embulk:embulk-test:0.9.7"
-    testCompile  "org.embulk:embulk-standards:0.9.7"
+    testCompile  "org.embulk:embulk-test:0.9.20"
+    testCompile  "org.embulk:embulk-standards:0.9.20"
 }
 
 task classpath(type: Copy, dependsOn: ["jar"]) {


### PR DESCRIPTION
Thanks for creating/maintaining this Embulk plugin!

We now plan to remove `io.netty:netty-common` and `io.netty:netty-buffer` from `embulk-core`'s dependency libraries. (More accurately, hiding it from plugins.) Once we do it, I guess it can start to fail.

I think that including them in this plugin should not cause a problem, as long as they are the same versions with `embulk-core`'s.

* With older Embulk still with  `io.netty:netty-common` and `io.netty:netty-buffer`, they are loaded from `embulk-core`'s.
* With upcoming Embulk without `io.netty:netty-common` and `io.netty:netty-buffer`, they are loaded from this plugin's.

What do you think?