### PR TITLE
feat!: Change the behavior of handling temporal data and fix some missing implmentations

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,31 +21,31 @@ But future embulk version may break this plugin.
 
 ## Support Data types
 
-| CQL Type                    | Embulk Type                                    | Descritpion                                                             |
-| --------                    | -----------                                    | --------------                                                          |
-| ascii                       | string, boolean, long, double, timestamp, json | use `toString` or `toJson`                                              |
-| bigint                      | string, boolean(as 0 or 1), long, double       |                                                                         |
-| blob                        | unsupported                                    |                                                                         |
-| boolean                     | boolean, long, double                          | 0 == false, 1 == true                                                   |
-| counter                     | unsupported                                    |                                                                         |
-| date                        | string, timestamp                              | timestamp use `toEpochMilli`                                            |
-| decimal                     | string, boolean(as 0 or 1), long, double       |                                                                         |
-| double                      | string, boolean(as 0 or 1), long, double       |                                                                         |
-| float                       | string, boolean(as 0 or 1), long, double       |                                                                         |
-| inet                        | string                                         |                                                                         |
-| int                         | string, boolean(as 0 or 1), long, double       | overflowed value is reset to 0                                          |
-| list                        | json                                           |                                                                         |
-| map (support only text key) | json                                           |                                                                         |
-| set                         | json                                           |                                                                         |
-| smallint                    | string, boolean(as 0 or 1), long, double       | overflowed value is reset to 0                                          |
-| text                        | string, boolean, long, double, timestamp, json | use `toString` or `toJson`                                              |
-| time                        | string, long, double, timestamp                | long and double as nano seconds of day,<br>timestamp use `toEpochMilli` |
-| timestamp                   | long, double, timestamp                        | long and double as epoch second                                         |
-| timeuuid                    | null                                           |
-| uuid                        | null                                           |
-| varchar                     | string, boolean, long, double, timestamp, json | use `toString` or `toJson`                                              |
-| varint                      | string, boolean(as 0 or 1), long, double       |                                                                         |
-| UDT                         | unsupported                                    |                                                                         |
+| CQL Type                    | Embulk Type                                    | Descritpion                                                           |
+| --------                    | -----------                                    | --------------                                                        |
+| ascii                       | string, boolean, long, double, timestamp, json | use `toString` or `toJson`                                            |
+| bigint                      | string, boolean(as 0 or 1), long, double       |                                                                       |
+| blob                        | unsupported                                    |                                                                       |
+| boolean                     | boolean, long, double                          | 0 == false, 1 == true                                                 |
+| counter                     | unsupported                                    |                                                                       |
+| date                        | string, long, timestamp                        | long as days from epoch, timestamp as UTC timestamp                   |
+| decimal                     | string, boolean(as 0 or 1), long, double       |                                                                       |
+| double                      | string, boolean(as 0 or 1), long, double       |                                                                       |
+| float                       | string, boolean(as 0 or 1), long, double       |                                                                       |
+| inet                        | string                                         |                                                                       |
+| int                         | string, boolean(as 0 or 1), long, double       | overflowed value is reset to 0                                        |
+| list                        | json                                           |                                                                       |
+| map (support only text key) | json                                           |                                                                       |
+| set                         | json                                           |                                                                       |
+| smallint                    | string, boolean(as 0 or 1), long, double       | overflowed value is reset to 0                                        |
+| text                        | string, boolean, long, double, timestamp, json | use `toString` or `toJson`                                            |
+| time                        | string, long, double, timestamp                | long and double as nano seconds of day,<br>timestamp as UTC timestamp |
+| timestamp                   | string, long, double, timestamp                | string as Java's ISO_INSTANT format, long and double as epoch millis  |
+| timeuuid                    | null                                           |                                                                       |
+| uuid                        | null                                           |                                                                       |
+| varchar                     | string, boolean, long, double, timestamp, json | use `toString` or `toJson`                                            |
+| varint                      | string, boolean(as 0 or 1), long, double       |                                                                       |
+| UDT                         | unsupported                                    |                                                                       |
 
 ## Insert Behavior
 If embulk record does not have a column, it is treated as `unset`.

--- a/src/main/java/org/embulk/output/cassandra/converter/Converters.java
+++ b/src/main/java/org/embulk/output/cassandra/converter/Converters.java
@@ -4,6 +4,7 @@ public class Converters {
   public static final StringConverter STRING = new StringConverter();
   public static final BigintConverter BIGINT = new BigintConverter();
   public static final BooleanConverter BOOLEAN = new BooleanConverter();
+  public static final DateConverter DATE = new DateConverter();
   public static final DecimalConverter DECIMAL = new DecimalConverter();
   public static final DoubleConverter DOUBLE = new DoubleConverter();
   public static final DurationConverter DURATION = new DurationConverter();
@@ -11,9 +12,12 @@ public class Converters {
   public static final InetConverter INET = new InetConverter();
   public static final IntConverter INT = new IntConverter();
   public static final SmallintConverter SMALLINT = new SmallintConverter();
+  public static final TimeConverter TIME = new TimeConverter();
   public static final TimestampConverter TIMESTAMP = new TimestampConverter();
   public static final TimeuuidConverter TIMEUUID = new TimeuuidConverter();
   public static final TinyintConverter TINYINT = new TinyintConverter();
   public static final UuidConverter UUID = new UuidConverter();
   public static final VarintConverter VARINT = new VarintConverter();
+
+  private Converters() {}
 }

--- a/src/main/java/org/embulk/output/cassandra/converter/DateConverter.java
+++ b/src/main/java/org/embulk/output/cassandra/converter/DateConverter.java
@@ -13,6 +13,8 @@ public class DateConverter implements Converter {
 
     if (value.isJsonString()) {
       return LocalDate.parse(value.asJsonString().getString());
+    } else if (value.isJsonLong()) {
+      return LocalDate.ofEpochDay(value.asJsonLong().longValue());
     } else {
       throw new UnsupportedOperationException(exceptionMessage(value));
     }

--- a/src/main/java/org/embulk/output/cassandra/converter/TimeConverter.java
+++ b/src/main/java/org/embulk/output/cassandra/converter/TimeConverter.java
@@ -1,22 +1,22 @@
 package org.embulk.output.cassandra.converter;
 
 import com.datastax.oss.driver.api.core.type.DataType;
-import java.time.Instant;
+import java.time.LocalTime;
 import org.embulk.spi.json.JsonValue;
 
-public class TimestampConverter implements Converter {
+public class TimeConverter implements Converter {
   @Override
-  public Instant convertJsonValue(DataType dataType, JsonValue value) {
+  public LocalTime convertJsonValue(DataType dataType, JsonValue value) {
     if (value.isJsonNull()) {
       return null;
     }
 
     if (value.isJsonString()) {
-      return Instant.parse(value.asJsonString().getString());
+      return LocalTime.parse(value.asJsonString().getString());
     } else if (value.isJsonLong()) {
-      return Instant.ofEpochMilli(value.asJsonLong().longValue());
+      return LocalTime.ofNanoOfDay(value.asJsonLong().longValue());
     } else if (value.isJsonDouble()) {
-      return Instant.ofEpochMilli(value.asJsonDouble().longValue());
+      return LocalTime.ofNanoOfDay(value.asJsonDouble().longValue());
     } else {
       throw new UnsupportedOperationException(exceptionMessage(value));
     }

--- a/src/main/java/org/embulk/output/cassandra/converter/ValueConverter.java
+++ b/src/main/java/org/embulk/output/cassandra/converter/ValueConverter.java
@@ -35,6 +35,8 @@ public class ValueConverter {
         return GenericType.BOOLEAN;
       } else if (dataType.equals(DataTypes.COUNTER)) {
         return GenericType.LONG;
+      } else if (dataType.equals(DataTypes.DATE)) {
+        return GenericType.LOCAL_DATE;
       } else if (dataType.equals(DataTypes.DECIMAL)) {
         return GenericType.BIG_DECIMAL;
       } else if (dataType.equals(DataTypes.DOUBLE)) {
@@ -53,6 +55,8 @@ public class ValueConverter {
         return GenericType.STRING;
       } else if (dataType.equals(DataTypes.TINYINT)) {
         return GenericType.BYTE;
+      } else if (dataType.equals(DataTypes.TIME)) {
+        return GenericType.LOCAL_TIME;
       } else if (dataType.equals(DataTypes.TIMESTAMP)) {
         return GenericType.INSTANT;
       } else if (dataType.equals(DataTypes.TIMEUUID)) {
@@ -144,6 +148,8 @@ public class ValueConverter {
       return Converters.BOOLEAN.convertJsonValue(dataType, value);
     } else if (dataType.equals(DataTypes.COUNTER)) {
       return Converters.BIGINT.convertJsonValue(dataType, value);
+    } else if (dataType.equals(DataTypes.DATE)) {
+      return Converters.DATE.convertJsonValue(dataType, value);
     } else if (dataType.equals(DataTypes.DECIMAL)) {
       return Converters.DECIMAL.convertJsonValue(dataType, value);
     } else if (dataType.equals(DataTypes.DOUBLE)) {
@@ -162,6 +168,8 @@ public class ValueConverter {
       return Converters.STRING.convertJsonValue(dataType, value);
     } else if (dataType.equals(DataTypes.TINYINT)) {
       return Converters.TINYINT.convertJsonValue(dataType, value);
+    } else if (dataType.equals(DataTypes.TIME)) {
+      return Converters.TIME.convertJsonValue(dataType, value);
     } else if (dataType.equals(DataTypes.TIMESTAMP)) {
       return Converters.TIMESTAMP.convertJsonValue(dataType, value);
     } else if (dataType.equals(DataTypes.TIMEUUID)) {

--- a/src/main/java/org/embulk/output/cassandra/setter/DateColumnSetter.java
+++ b/src/main/java/org/embulk/output/cassandra/setter/DateColumnSetter.java
@@ -11,6 +11,12 @@ public class DateColumnSetter extends CassandraColumnSetter {
   }
 
   @Override
+  public void setLongValue(Long value, BoundStatementBuilder statement) {
+    LocalDate date = LocalDate.ofEpochDay(value);
+    statement.setLocalDate(cassandraColumn.getName(), date);
+  }
+
+  @Override
   public void setStringValue(String value, BoundStatementBuilder statement) {
     LocalDate date = LocalDate.parse(value);
     statement.setLocalDate(cassandraColumn.getName(), date);

--- a/src/main/java/org/embulk/output/cassandra/setter/TimestampColumnSetter.java
+++ b/src/main/java/org/embulk/output/cassandra/setter/TimestampColumnSetter.java
@@ -11,19 +11,18 @@ public class TimestampColumnSetter extends CassandraColumnSetter {
 
   @Override
   public void setLongValue(Long value, BoundStatementBuilder statement) {
-    statement.setInstant(cassandraColumn.getName(), Instant.ofEpochSecond(value));
+    statement.setInstant(cassandraColumn.getName(), Instant.ofEpochMilli(value));
   }
 
   @Override
   public void setDoubleValue(Double value, BoundStatementBuilder statement) {
     long longValue = value.longValue();
-    long nanoSecond = Math.round((value - longValue) * 1_000_000_000);
-    statement.setInstant(cassandraColumn.getName(), Instant.ofEpochSecond(longValue, nanoSecond));
+    statement.setInstant(cassandraColumn.getName(), Instant.ofEpochMilli(longValue));
   }
 
   @Override
   public void setStringValue(String value, BoundStatementBuilder statement) {
-    statement.setString(cassandraColumn.getName(), value);
+    statement.setInstant(cassandraColumn.getName(), Instant.parse(value));
   }
 
   @Override

--- a/src/test/resources/org/embulk/output/cassandra/create_table_test_integer_as_temporal.cql
+++ b/src/test/resources/org/embulk/output/cassandra/create_table_test_integer_as_temporal.cql
@@ -1,0 +1,7 @@
+CREATE TABLE IF NOT EXISTS embulk_test.test_integer_as_temporal (
+  id text,
+  timestamp_item timestamp,
+  date_item date,
+  time_item time,
+  primary key (id)
+) WITH compaction = { 'class' : 'SizeTieredCompactionStrategy' };

--- a/src/test/resources/org/embulk/output/cassandra/test4.csv
+++ b/src/test/resources/org/embulk/output/cassandra/test4.csv
@@ -1,0 +1,2 @@
+id:string,timestamp_item:long,date_item:long,time_item:long
+A001,86400000,1,600000000000

--- a/src/test/resources/org/embulk/output/cassandra/test_integer_as_temporal.yaml
+++ b/src/test/resources/org/embulk/output/cassandra/test_integer_as_temporal.yaml
@@ -1,0 +1,4 @@
+type: cassandra
+keyspace: embulk_test
+table: "test_integer_as_temporal"
+port: 9142


### PR DESCRIPTION
Importatnt changes:
- `timestamp` column accepts string as Java's ISO_INSTANT format.
- `timestamp` column accepts long and double as epoch millis. (before: as epoch seconds)
- `date` column accepts long as days from epoch. (before: not supported)
